### PR TITLE
fix issue with example-block-style-js

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,12 +1,14 @@
 {
-	"phpVersion": "7.4",
+	"phpVersion": "8",
 	"port": 3333,
+	"core": "WordPress/WordPress#6.4",
 	"themes": [
 		"./example-block-style-js",
 		"./example-block-style-php",
 		"./example-block-stylesheet",
 		"./example-block-variation",
 		"./example-build-process",
+		"./example-locked-pattern",
 		"./example-template-part-area",
 		"https://downloads.wordpress.org/theme/twentytwentyfour.1.0.zip"
 	],

--- a/example-block-style-js/functions.php
+++ b/example-block-style-js/functions.php
@@ -20,7 +20,7 @@ function themeslug_editor_styles() {
 	add_editor_style( get_stylesheet_uri() );
 }
 
-add_action( 'wp_enqueue_scripts', 'themeslug_enqueue_styles' );
+add_action( 'enqueue_block_assets', 'themeslug_enqueue_styles' );
 
 /**
  * Enqueues the `style.css` file for the front end.


### PR DESCRIPTION
FIxes https://github.com/wptrainingteam/block-theme-examples/issues/9
Also specify WP 6.4 for wp-env

The styles weren't added to the iframe so this PR solves this issue with the use of `enqueue_block_assets`

> As of WordPress 6.3, all assets added through the [enqueue_block_assets](https://developer.wordpress.org/reference/hooks/enqueue_block_assets/) PHP action will also be enqueued in the iframed Editor. See [#48286](https://github.com/WordPress/gutenberg/pull/48286) for more details (source: [Enqueueing assets in the Editor](https://developer.wordpress.org/redesign-test/block-editor/how-to-guides/enqueueing-assets-in-the-editor/))